### PR TITLE
changed line start ddram address offsets

### DIFF
--- a/src/lcd/lcd_driver_hd44780_module.vhd
+++ b/src/lcd/lcd_driver_hd44780_module.vhd
@@ -373,14 +373,14 @@ BEGIN
 
 				WHEN command_goto20 =>
 					-- Cursor to beginning of line 3rd line...
-					LCD_DB <= "10010000"; --0x80+0x10;
+					LCD_DB <= "10010100"; --0x80+0x14;
 					LCD_RS <= '0';
 					current_state <= pulse_e;
 					return_state <= wait_for_command;
 
 				WHEN command_goto30 =>
 					-- Cursor to beginning of line 4th line...
-					LCD_DB <= "11010000"; --0x80+0x50;
+					LCD_DB <= "11010100"; --0x80+0x54;
 					LCD_RS <= '0';
 					current_state <= pulse_e;
 					return_state <= wait_for_command;

--- a/src/lcd/spacewire_lcd_driver.vhd
+++ b/src/lcd/spacewire_lcd_driver.vhd
@@ -173,14 +173,14 @@ ARCHITECTURE hardware OF spacewire_lcd_driver IS
 	CONSTANT empty_message : message4x20_type := (
 		1 => stringPadding("No Data", 20),
 		2 => convertData("0000000000000000", "x: ", "g", 2, 4),
-		3 => convertData("0000000000000000", "    y: ", "g", 2, 4),
-		4 => convertData("0000000000000000", "    z: ", "g", 2, 4)
+		3 => convertData("0000000000000000", "y: ", "g", 2, 4),
+		4 => convertData("0000000000000000", "z: ", "g", 2, 4)
 	);
 	CONSTANT debug_message : message4x20_type := (
 		1 => stringPadding("Debug", 20),
 		2 => convertData("0111111111111111", "x: ", "g", 2, 4),
-		3 => convertData("0000000000000000", "    y: ", "g", 2, 4),
-		4 => convertData("0111111111111111", "    z: ", "g", 2, 4)
+		3 => convertData("0000000000000000", "y: ", "g", 2, 4),
+		4 => convertData("0111111111111111", "z: ", "g", 2, 4)
 	);
 	SIGNAL message : message4x20_type := empty_message; 
 


### PR DESCRIPTION
According to convention lines 1 and 2 start at 0x0 and 0x40 and lines 3 and 4 start after those, which on 16x4 LCD would be 0x10 and 0x50. We have a 20x4 display so the correct offsets should be 0x14 and 0x54